### PR TITLE
Log out user on 401 response.

### DIFF
--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -15,19 +15,19 @@ const protect = asyncHandler(async (req, res, next) => {
             req.user = await User.findById(decoded.id).select('-password');
             if (!req.user) {
                 res.status(401);
-                throw new Error('Not authirised');
+                throw new Error('Not authorised');
             }
 
             next();
         } catch (error) {
             res.status(401);
-            throw new Error('Not authirised');
+            throw new Error('Not authorised');
         }
     }
 
     if (!token) {
         res.status(401);
-        throw new Error('Not authirised');
+        throw new Error('Not authorised');
     }
 });
 

--- a/frontend/src/features/api.js
+++ b/frontend/src/features/api.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { store } from '../app/store';
+import { logout } from './auth/authSlice';
+
+// Create an instance of axios
+const api = axios.create({
+    baseURL: '/api',
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+/*
+  NOTE: intercept any error responses from the api
+ and check if the token is no longer valid.
+ ie. Token has expired or user is no longer
+ authenticated.
+ logout the user if the token has expired
+*/
+
+api.interceptors.response.use(
+    (res) => res,
+    (err) => {
+        if (err.response.status === 401) {
+            store.dispatch(logout());
+        }
+        return Promise.reject(err);
+    }
+);
+
+export default api;

--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -1,10 +1,10 @@
-import axios from 'axios';
+import api from '../api';
 
-const API_URL = '/api/users';
+const API_URL = '/users';
 
 // Register user
 const register = async (userData) => {
-    const response = await axios.post(API_URL, userData);
+    const response = await api.post(API_URL, userData);
 
     if (response.data) {
         localStorage.setItem('user', JSON.stringify(response.data));
@@ -14,7 +14,7 @@ const register = async (userData) => {
 
 // Login user
 const login = async (userData) => {
-    const response = await axios.post(`${API_URL}/login`, userData);
+    const response = await api.post(`${API_URL}/login`, userData);
 
     if (response.data) {
         localStorage.setItem('user', JSON.stringify(response.data));

--- a/frontend/src/features/notes/noteService.js
+++ b/frontend/src/features/notes/noteService.js
@@ -1,6 +1,6 @@
-import axios from 'axios';
+import api from '../api';
 
-const API_URL = '/api/tickets';
+const API_URL = '/tickets';
 
 // Get ticket notes
 const getNotes = async (ticketId, token) => {
@@ -9,7 +9,7 @@ const getNotes = async (ticketId, token) => {
             Authorization: `Bearer ${token}`,
         },
     };
-    const response = await axios.get(`${API_URL}/${ticketId}/notes`, config);
+    const response = await api.get(`${API_URL}/${ticketId}/notes`, config);
     return response.data;
 };
 
@@ -20,7 +20,7 @@ const createNote = async (noteText, ticketId, token) => {
             Authorization: `Bearer ${token}`,
         },
     };
-    const response = await axios.post(`${API_URL}/${ticketId}/notes`, { text: noteText }, config);
+    const response = await api.post(`${API_URL}/${ticketId}/notes`, { text: noteText }, config);
     return response.data;
 };
 

--- a/frontend/src/features/notes/noteService.js
+++ b/frontend/src/features/notes/noteService.js
@@ -1,26 +1,21 @@
 import api from '../api';
+import { createAuthConfig } from '../../utils';
 
 const API_URL = '/tickets';
 
 // Get ticket notes
 const getNotes = async (ticketId, token) => {
-    const config = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    };
-    const response = await api.get(`${API_URL}/${ticketId}/notes`, config);
+    const response = await api.get(`${API_URL}/${ticketId}/notes`, createAuthConfig(token));
     return response.data;
 };
 
 // Create ticket note
 const createNote = async (noteText, ticketId, token) => {
-    const config = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    };
-    const response = await api.post(`${API_URL}/${ticketId}/notes`, { text: noteText }, config);
+    const response = await api.post(
+        `${API_URL}/${ticketId}/notes`,
+        { text: noteText },
+        createAuthConfig(token)
+    );
     return response.data;
 };
 

--- a/frontend/src/features/tickets/ticketService.js
+++ b/frontend/src/features/tickets/ticketService.js
@@ -1,6 +1,6 @@
-import axios from 'axios';
+import api from '../api';
 
-const API_URL = '/api/tickets';
+const API_URL = '/tickets';
 
 // Create new ticket
 const createTicket = async (ticketData, token) => {
@@ -9,7 +9,7 @@ const createTicket = async (ticketData, token) => {
             Authorization: `Bearer ${token}`,
         },
     };
-    const response = await axios.post(API_URL, ticketData, config);
+    const response = await api.post(API_URL, ticketData, config);
     return response.data;
 };
 
@@ -20,7 +20,7 @@ const getTickets = async (token) => {
             Authorization: `Bearer ${token}`,
         },
     };
-    const response = await axios.get(API_URL, config);
+    const response = await api.get(API_URL, config);
     return response.data;
 };
 
@@ -31,7 +31,7 @@ const getTicket = async (ticketID, token) => {
             Authorization: `Bearer ${token}`,
         },
     };
-    const response = await axios.get(`${API_URL}/${ticketID}`, config);
+    const response = await api.get(`${API_URL}/${ticketID}`, config);
     return response.data;
 };
 
@@ -42,7 +42,7 @@ const closeTicket = async (ticketID, token) => {
             Authorization: `Bearer ${token}`,
         },
     };
-    const response = await axios.put(`${API_URL}/${ticketID}`, { status: 'closed' }, config);
+    const response = await api.put(`${API_URL}/${ticketID}`, { status: 'closed' }, config);
     return response.data;
 };
 

--- a/frontend/src/features/tickets/ticketService.js
+++ b/frontend/src/features/tickets/ticketService.js
@@ -1,48 +1,33 @@
 import api from '../api';
+import { createAuthConfig } from '../../utils';
 
 const API_URL = '/tickets';
 
 // Create new ticket
 const createTicket = async (ticketData, token) => {
-    const config = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    };
-    const response = await api.post(API_URL, ticketData, config);
+    const response = await api.post(API_URL, ticketData, createAuthConfig(token));
     return response.data;
 };
 
 // Get user tickets
 const getTickets = async (token) => {
-    const config = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    };
-    const response = await api.get(API_URL, config);
+    const response = await api.get(API_URL, createAuthConfig(token));
     return response.data;
 };
 
 // Get single ticket
 const getTicket = async (ticketID, token) => {
-    const config = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    };
-    const response = await api.get(`${API_URL}/${ticketID}`, config);
+    const response = await api.get(`${API_URL}/${ticketID}`, createAuthConfig(token));
     return response.data;
 };
 
 // Close ticket
 const closeTicket = async (ticketID, token) => {
-    const config = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    };
-    const response = await api.put(`${API_URL}/${ticketID}`, { status: 'closed' }, config);
+    const response = await api.put(
+        `${API_URL}/${ticketID}`,
+        { status: 'closed' },
+        createAuthConfig(token)
+    );
     return response.data;
 };
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,3 +1,11 @@
 export function extractErrorMessage(error) {
     return error.response?.data?.message || error.message || error.toString();
 }
+
+export function createAuthConfig(token) {
+    return {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    };
+}


### PR DESCRIPTION
Currently if the users JWT expires or is tampered with in LS then it is no longer valid and we will get a 401 response from our backend, but this is not handled in the frontend. You would most likely see an infinite Spinner and until the user manually clears local storage the app will be unusable. 
This PR solves that by using an instance of axios and adding an 'interceptor' which will intercept any 401 unauthorized responses and then logout the user in Redux and clear local storage by dispatching our logout action.
The authService, noteService and ticketService then use this instance of axios instead of axios directly.
Additionally this PR cleans up the repetitive code in creating a config with our Authorization headers by using a utility function.